### PR TITLE
Make EdgeHTML open source

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,4 +94,6 @@ To provide a more specific sense of what actions we’ll take with and following
 3. We’ll make a public announcement via blog post so that the external community of people interested will have a transparent view of our strategy change. 
 4. We’ll post this document to GitHub so any interested developer or web-community member can read about our plans directly.
 
+Whilst that we're also going to release the EdgeHTML rendering engine as open-source, just as we did with the ChakraCore.
+
 We invite your comments, advice, and feedback as we begin to engage with you on the Chromium project!


### PR DESCRIPTION
As another big step I would like to see EdgeHTML open sourced just as MS did with the ChakraCore. ChakraCore is a rip-off from the IE just as EdgeHTML is a refreshed version of Trident from IE. So why not? Don't see this as real pull request, more like a christmas wish 🎅 